### PR TITLE
Add `hover-ancestor` mixin

### DIFF
--- a/lib/input.styl
+++ b/lib/input.styl
@@ -40,3 +40,31 @@ active(addActiveSelector = true)
 	if addActiveSelector
 		&.active
 			{block}
+
+/**
+ * Hover Ancestor: Apply styles to an element when we hover one of its ancestors.
+ * Ex:
+ *   .card-title
+ *     background grey
+ *     +hover-ancestor(".card", true)
+ *       background black
+ */
+hover-ancestor(ancestor, includeActive = false)
+	if ancestor is undefined
+		warn("hover-ancestor mixin requires an ancestor")
+	.no-touchevents {ancestor}:hover &
+		{block}
+	if includeActive
+		+active-ancestor(ancestor)
+			{block}
+
+// Apply active to both touch and non-touch
+active-ancestor(ancestor, addActiveSelector = true)
+	if ancestor is undefined
+		warn("hover-ancestor mixin requires an ancestor")
+	.no-touchevents {ancestor}:active &,
+	{ancestor}:active &
+		{block}
+	if addActiveSelector
+		{ancestor}.active &
+			{block}

--- a/lib/input.styl
+++ b/lib/input.styl
@@ -61,7 +61,7 @@ hover-ancestor(ancestor, includeActive = false)
 // Apply active to both touch and non-touch
 active-ancestor(ancestor, addActiveSelector = true)
 	if ancestor is undefined
-		warn("hover-ancestor mixin requires an ancestor")
+		warn("active-ancestor mixin requires an ancestor")
 	.no-touchevents {ancestor}:active &,
 	{ancestor}:active &
 		{block}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bukwild-stylus-library",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Stylus utility mixins",
   "main": "index.styl",
   "repository": {


### PR DESCRIPTION
I added this `hover-ancestor` mixin to my current project and I'm finding it useful.  I thought I'd add it here too.

Side note, this bumps version to 2.3.0.  Current version on NPM is 2.3.0 too.  My fork has 2.3.0, not sure why this repo still has 2.2.2.